### PR TITLE
Documentation typo: duplication

### DIFF
--- a/near_deduplication/README.md
+++ b/near_deduplication/README.md
@@ -27,8 +27,6 @@ python minhash_deduplication.py --dataset codeparrot/codeparrot-clean-valid \
     --column content \
     --cache-dir .cache \
     --min-ngram-size 5
-# For details on the arguments, see the help message
-python minhash_deduplication.py --help
 ```
 
 Spark Script


### PR DESCRIPTION
Removed duplication of the following code snippet:
```bash
# For details on the arguments, see the help message
python minhash_deduplication.py --help
```